### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: false
 language: python
 python: 3.7
 install:
-  pip install --quiet -r requirements.txt
+  pip install --quiet flake8 -r requirements.txt
+before_script:
+  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script:
   python -m unittest discover tests
 after_success:

--- a/ceviche/fdfd.py
+++ b/ceviche/fdfd.py
@@ -553,9 +553,9 @@ def createDws(w, s, dL, shape):
 
     Nx, Ny = shape
 
-    if w is 'x':
+    if w == 'x':
         if Nx > 1:
-            if s is 'f':
+            if s == 'f':
                 dxf = sp.diags([-1, 1, 1], [0, 1, -Nx+1], shape=(Nx, Nx))
                 Dws = 1 / dL * sp.kron(dxf, sp.eye(Ny))
             else:
@@ -563,9 +563,9 @@ def createDws(w, s, dL, shape):
                 Dws = 1 / dL * sp.kron(dxb, sp.eye(Ny))
         else:
             Dws = sp.eye(Ny)            
-    if w is 'y':
+    if w == 'y':
         if Ny > 1:
-            if s is 'f':
+            if s == 'f':
                 dyf = sp.diags([-1, 1, 1], [0, 1, -Ny+1], shape=(Ny, Ny))
                 Dws = 1 / dL * sp.kron(sp.eye(Nx), dyf)
             else:
@@ -597,12 +597,12 @@ def create_sfactor(s, omega, dL, N, N_pml):
     dw = N_pml * dL
 
     for i in range(N):
-        if s is 'f':
+        if s == 'f':
             if i <= N_pml:
                 sfactor_vecay[i] = S(dL * (N_pml - i + 0.5), dw, omega)
             elif i > N - N_pml:
                 sfactor_vecay[i] = S(dL * (i - (N - N_pml) - 0.5), dw, omega)
-        if s is 'b':
+        if s == 'b':
             if i <= N_pml:
                 sfactor_vecay[i] = S(dL * (N_pml - i + 1), dw, omega)
             elif i > N - N_pml:


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

Also, the __sudo:__ tag is deprecated in Travis CI.